### PR TITLE
Fixed: main target should be js version, not coffee source

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cozy-ical",
   "version": "1.0.1",
   "description": "Cozy-Ical provides ICal Parser, generators and helpers",
-  "main": "src/index",
+  "main": "lib/index",
   "scripts": {
     "test": "cake tests",
     "build": "coffee -cb --output lib/ src/",


### PR DESCRIPTION
I forgot to change that back after my work on cozy-ical, resulting in the project to break when run from a JavaScript.
