### PR TITLE
Add X-WR-CALNAME field support, and fix last line parse.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "moment-timezone": "0.2.4",
     "rrule": "2.1.0",
-    "lazy": "1.0.11",
+    "byline": "4.1.1",
     "printit": "0.1.3",
     "extend": "2.0.0",
     "uuid": "^2.0.1"

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,6 +1,7 @@
 fs = require 'fs'
 moment = require 'moment-timezone'
-lazy = require 'lazy'
+byline = require 'byline'
+stream = require 'stream'
 extend = require 'extend'
 uuid = require 'uuid'
 {RRule} = require 'rrule'
@@ -744,23 +745,17 @@ module.exports.ICalParser = class ICalParser
         @parse fs.createReadStream(file), callback
 
     parseString: (string, callback) ->
-        class FakeStream extends require('events').EventEmitter
-            readable: true
-            writable: false
-            setEncoding: -> throw new Error 'not implemented'
-            pipe: -> throw new Error 'not implemented'
-            destroy: ->  # nothing to do
-            resume: ->   # nothing to do
-            pause: ->    # nothing to do
-            send: (string) ->
-                @emit 'data', string
-                @emit 'end'
+        fakeStream = new stream.Readable()
+        
+        fakeStream._read = ->
 
-        fakeStream = new FakeStream
         @parse fakeStream, callback
-        fakeStream.send string
+
+        fakeStream.push string
+        fakeStream.push null
 
     parse: (stream, callback) ->
+        stream = byline(stream)
         result = {}
         noerror = true
         lineNumber = 0
@@ -819,18 +814,21 @@ module.exports.ICalParser = class ICalParser
                 else
                     sendError "Malformed ical file"
 
-        lazy(stream).lines.forEach (line) ->
-            lineNumber++
+        stream.on 'data', (line)->
+            stream.pause()
 
+            lineNumber++
             line = line.toString('utf-8').replace "\r", ''
 
             # Skip blank lines and a strange behaviour :
             # empty lines become <Buffer 30> which is '0' .
             if line is '' or line is '0'
-                return
+                return stream.resume()
 
             if line[0] is ' '
                 completeLine += line.substring 1
             else
                 lineParser completeLine if completeLine
                 completeLine = line
+
+            stream.resume()


### PR DESCRIPTION
Add standard but non-normative X-WR-CALNAME field support to export and import calendar name.
Switch from lazy to byline library to parse iCal files line by line. Update fakeStream object to comply with this new lib.
Tested with multiples files in cozy-calendar and still working in cozy-sync.
