### PR TITLE
Check `@getRawField 'PRODID'` for return value

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -158,9 +158,11 @@ module.exports.VCalendar = class VCalendar extends VComponent
 
     extract: ->
         super()
-        {value} = @getRawField 'PRODID'
-        extractPRODID = /-\/\/([\w. ]+)\/\/?(?:NONSGML )?(.+)\/\/.*/
-        results = value.match extractPRODID
+        prodId = @getRawField 'PRODID'
+        if prodId
+            {value} = prodId
+            extractPRODID = /-\/\/([\w. ]+)\/\/?(?:NONSGML )?(.+)\/\/.*/
+            results = value.match extractPRODID
 
         if results?
             [_, organization, title] = results


### PR DESCRIPTION
Check `@getRawField 'PRODID'` for return value before getting `value` field. Was getting a breaking error on an ical feed without a PRODID field (created in Calendar in OS X)