### PR TITLE
Few fixes

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -547,6 +547,14 @@ module.exports.VEvent = class VEvent extends VComponent
                 if dtstart.details[0] is 'VALUE=DATE'
                     timezoneStart = 'UTC'
                     allDay = true
+                else if dtstart.details[0] is 'VALUE=DATE-TIME'
+                    timezoneInfos = dtstart.details[1]
+                    if timezoneInfos?
+                        [_, timezoneStart] = dtstart.details[1].split '='
+                        if timezoneStart not in VALID_TZ_LIST
+                            timezoneStart = 'UTC'
+                    else
+                        timezoneStart = 'UTC'
                 else
                     [_, timezoneStart] = dtstart.details[0].split '='
                     if timezoneStart not in VALID_TZ_LIST
@@ -596,9 +604,20 @@ module.exports.VEvent = class VEvent extends VComponent
         else if endDate?
             # details for a dtend field is timezone indicator
             if dtend.details?.length > 0
-                [_, timezoneEnd] = dtend.details[0].split '='
-                if timezoneEnd not in VALID_TZ_LIST
+                if dtend.details[0] is 'VALUE=DATE'
                     timezoneEnd = 'UTC'
+                else if dtend.details[0] is 'VALUE=DATE-TIME'
+                    timezoneInfos = dtend.details[1]
+                    if timezoneInfos?
+                        [_, timezoneEnd] = dtend.details[1].split '='
+                        if timezoneEnd not in VALID_TZ_LIST
+                            timezoneEnd = 'UTC'
+                    else
+                        timezoneEnd = 'UTC'
+                else
+                    [_, timezoneEnd] = dtend.details[0].split '='
+                    if timezoneEnd not in VALID_TZ_LIST
+                        timezoneEnd = 'UTC'
             else
                 # if there is no timezone indicator, the date is in local time
                 if dtend.value.length is 15

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -617,11 +617,16 @@ module.exports.VEvent = class VEvent extends VComponent
                 rrule = rrule.split(';')
 
                     .map (part) ->
-                        # If it's the 'UNTIL' property and that it doesn't have
-                        # a Z at the end, append it. (see #305)
-                        if part.indexOf('UNTIL') isnt -1 and
-                           part[part.length - 1] isnt 'Z'
-                            part += 'Z'
+                        # If it's the 'UNTIL' property.
+                        isUntil = part.indexOf('UNTIL') isnt -1
+                        if isUntil
+                            # And if it has a DATE-TIME type, and that it
+                            # doesn't have a Z at the end, append it. (see #305).
+                            [_, dateSection] = part.split('=')
+                            isDateTime =  dateSection.indexOf('T') isnt -1
+                            hasZAtTheEnd = part[part.length - 1] is 'Z'
+                            if isDateTime and not hasZAtTheEnd
+                                part += 'Z'
 
                         return part
 

--- a/test/auto-correct-until.coffee
+++ b/test/auto-correct-until.coffee
@@ -6,40 +6,82 @@ moment = require 'moment-timezone'
 
 describe "Import ICS with UNTIL property without 'Z' at the end", ->
 
-    icsEvent = """
-    BEGIN:VCALENDAR
-    PRODID:-//Microsoft Corporation//Outlook 12.0 MIMEDIR//EN
-    VERSION:2.0
-    CALSCALE:GREGORIAN
-    BEGIN:VEVENT
-    CREATED:20150601T044431Z
-    LAST-MODIFIED:20150601T044431Z
-    DTSTAMP:20150601T044431Z
-    UID:123-456
-    SUMMARY:something random
-    RRULE:FREQ=WEEKLY;UNTIL=20141204T110000
-    DTSTART;TZID=Europe/Paris:20130307T110000
-    DTEND;TZID=Europe/Paris:20130307T120000
-    TRANSP:OPAQUE
-    SEQUENCE:0
-    END:VEVENT
-    END:VCALENDAR
-    """
+    # Until can be a DATE or a DATE-TIME
+
+    describe "When the date is a DATE-TIME", ->
+        icsEvent = """
+        BEGIN:VCALENDAR
+        PRODID:-//Microsoft Corporation//Outlook 12.0 MIMEDIR//EN
+        VERSION:2.0
+        CALSCALE:GREGORIAN
+        BEGIN:VEVENT
+        CREATED:20150601T044431Z
+        LAST-MODIFIED:20150601T044431Z
+        DTSTAMP:20150601T044431Z
+        UID:123-456
+        SUMMARY:something random
+        RRULE:FREQ=WEEKLY;UNTIL=20141204T110000
+        DTSTART;TZID=Europe/Paris:20130307T110000
+        DTEND;TZID=Europe/Paris:20130307T120000
+        TRANSP:OPAQUE
+        SEQUENCE:0
+        END:VEVENT
+        END:VCALENDAR
+        """
 
 
-    it "shouldn't return an error", (done) ->
-        parser = new ICalParser()
+        it "shouldn't return an error", (done) ->
+            parser = new ICalParser()
 
-        parser.parseString icsEvent, (err, result) =>
-            should.not.exist err
-            @result = result
-            should.exist @result
-            @result.should.have.property 'subComponents'
-            @result.subComponents.length.should.equal 1
-            done()
+            parser.parseString icsEvent, (err, result) =>
+                should.not.exist err
+                @result = result
+                should.exist @result
+                @result.should.have.property 'subComponents'
+                @result.subComponents.length.should.equal 1
+                done()
 
-    it "and the event should be well formed", ->
-        event = @result.subComponents[0].model
-        untilField = event.rrule.until
-        moment.tz(untilField, 'Europe/Paris').toISOString().should.equal  "2014-12-04T11:00:00.000Z"
+        it "and the event should be well formed", ->
+            event = @result.subComponents[0].model
+            untilField = event.rrule.until
+            moment.tz(untilField, 'Europe/Paris').toISOString().should.equal  "2014-12-04T11:00:00.000Z"
+
+
+    describe "When the date is a DATE", ->
+            icsEvent = """
+            BEGIN:VCALENDAR
+            PRODID:-//Microsoft Corporation//Outlook 12.0 MIMEDIR//EN
+            VERSION:2.0
+            CALSCALE:GREGORIAN
+            BEGIN:VEVENT
+            CREATED:20150601T044431Z
+            LAST-MODIFIED:20150601T044431Z
+            DTSTAMP:20150601T044431Z
+            UID:123-456
+            SUMMARY:something random
+            RRULE:FREQ=WEEKLY;UNTIL=20141204
+            DTSTART;TZID=Europe/Paris:20130307T110000
+            DTEND;TZID=Europe/Paris:20130307T120000
+            TRANSP:OPAQUE
+            SEQUENCE:0
+            END:VEVENT
+            END:VCALENDAR
+            """
+
+
+            it "shouldn't return an error", (done) ->
+                parser = new ICalParser()
+
+                parser.parseString icsEvent, (err, result) =>
+                    should.not.exist err
+                    @result = result
+                    should.exist @result
+                    @result.should.have.property 'subComponents'
+                    @result.subComponents.length.should.equal 1
+                    done()
+
+            it "and the event should be well formed", ->
+                event = @result.subComponents[0].model
+                untilField = event.rrule.until
+                moment.tz(untilField, 'Europe/Paris').toISOString().should.equal  "2014-12-04T00:00:00.000Z"
 

--- a/test/dt-start-value-date-time-with-tz.coffee
+++ b/test/dt-start-value-date-time-with-tz.coffee
@@ -1,0 +1,43 @@
+# Tests for the fix of bug https://forum.cozy.io/t/calendar-quelques-retours/875/25
+should = require 'should'
+moment = require 'moment-timezone'
+
+{ICalParser, decorateEvent} = require '../src/index'
+
+# mock classes
+Event = class Event
+    @dateFormat = 'YYYY-MM-DD'
+    @ambiguousDTFormat = 'YYYY-MM-DD[T]HH:mm:00.000'
+    @utcDTFormat = 'YYYY-MM-DD[T]HH:mm:00.000[Z]'
+
+describe "VALUE=DATE-TIME in DTSTART with a TZ indicator", ->
+
+    icsEvent = """
+    BEGIN:VCALENDAR
+    PRODID:-//Microsoft Corporation//Outlook 12.0 MIMEDIR//EN
+    VERSION:2.0
+    CALSCALE:GREGORIAN
+    BEGIN:VEVENT
+    UID:AF 32220150807T19100020150807T19100020150723T105024
+    DTSTAMP:20150723T105024
+    DTSTART;VALUE=DATE-TIME;TZID=Europe/Paris:20150807T191000
+    DTEND;VALUE=DATE-TIME;TZID=Europe/Paris:20150808T030000
+    END:VEVENT
+    END:VCALENDAR
+    """
+
+    it "shouldn't return an error", (done) ->
+        parser = new ICalParser()
+
+        parser.parseString icsEvent, (err, result) =>
+            should.not.exist err
+            @result = result
+            should.exist @result
+            @result.should.have.property 'subComponents'
+            @result.subComponents.length.should.equal 1
+            done()
+
+    it "and the event should be well formed", ->
+        event = @result.subComponents[0].model
+        moment.tz(event.startDate, 'Europe/Paris').toISOString().should.equal  "2015-08-07T17:10:00.000Z"
+        moment.tz(event.endDate, 'Europe/Paris').toISOString().should.equal  "2015-08-08T01:00:00.000Z"


### PR DESCRIPTION
* Fixed: one of the two cases of the UNTIL auto-correct was not taken into account.
The date format can be DATE or DATE-TIME. The 'Z' is only relevant in the case of a DATE-TIME, which caused an error when the type was DATE.

* Fixed: VALUE=DATE-TIME param was not taken into account in properties DTSTART and DTEND.
This resulted in the timezone being defaulted to UTC.