### PR TITLE
Fix uid field

### DIFF
--- a/src/event.coffee
+++ b/src/event.coffee
@@ -42,7 +42,7 @@ module.exports = (Event) ->
                 endDate: moment.tz @end, timezone
                 summary: @description
                 location: @place
-                uid: @id
+                uid: @uid or @id
                 description: @details
                 allDay: allDay
                 rrule: rrule
@@ -88,6 +88,7 @@ module.exports = (Event) ->
 
         timezone = model.timezone or 'UTC'
         event.id = model.uid if model.uid?
+        event.uid = model.uid if model.uid?
         event.description = model.summary or ''
         event.details = model.description or ''
         event.place = model.location

--- a/test/decorator.coffee
+++ b/test/decorator.coffee
@@ -62,7 +62,7 @@ describe "Cozy models decorator", ->
             # events comes from extractEvents, that uses fromIcal under the hood
             event = @events[0]
             should.exist event
-            event.should.have.property 'id', 'aeba6310b07a22a72423b2b11f320692'
+            event.should.have.property 'uid', 'aeba6310b07a22a72423b2b11f320692'
             event.should.have.property 'description', 'Recurring event'
             event.should.have.property 'start', '2014-11-06T12:00:00.000'
             event.should.have.property 'end', '2014-11-06T13:00:00.000'


### PR DESCRIPTION
UID was replaced by ID field during export to iCal, resulting in bug for some
provider such as iOS. Refs https://github.com/cozy/jsDAV/issues/21.

It still defaults to ID field, which is the UID of events which don't have one (e.g. those created by Cozy).